### PR TITLE
Fix compilation with Nim 2.2.0

### DIFF
--- a/src/boxy/blends.nim
+++ b/src/boxy/blends.nim
@@ -180,4 +180,4 @@ proc atlasVert*(
   pos = vertexPos
   uv = vertexUv
   color = vertexColor
-  gl_Position = proj * vec4(vertexPos.x, vertexPos.y, 0.0, 1.0)
+  gl_Position = proj.Mat4 * vec4(vertexPos.x, vertexPos.y, 0.0, 1.0)


### PR DESCRIPTION
Nim 2.2.0 breaks generics semantics like `X[T] = T` for some reason. This PR just fixes a compilation issue in the shader generation code.
